### PR TITLE
Discard Option for MDADM

### DIFF
--- a/ReadMe.c
+++ b/ReadMe.c
@@ -138,6 +138,7 @@ struct option long_options[] = {
     {"size",	  1, 0, 'z'},
     {"auto",	  1, 0, Auto}, /* also for --assemble */
     {"assume-clean",0,0, AssumeClean },
+    {"discard",	  0, 0, Discard },
     {"metadata",  1, 0, 'e'}, /* superblock format */
     {"bitmap",	  1, 0, Bitmap},
     {"bitmap-chunk", 1, 0, BitmapChunk},

--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -837,6 +837,21 @@ array is resynced at creation.  From Linux version 3.0,
 can be used with that command to avoid the automatic resync.
 
 .TP
+.BR \-\-discard
+When creating an array, send block discard (aka trim or deallocate)
+requests to all the block devices. In most cases this should zero all
+the disks. If any discard fails, or if zeros are not read back from the
+disk, then the operation will be aborted.
+.IP
+If all discards succeed, and there are no missing disks specified,
+then the array should not need to be synchronized after it is created
+(as all disks are zero). The operation will thus proceed as if
+.B \-\-assume\-clean
+was specified.
+.IP
+This is only meaningful with --create.
+
+.TP
 .BR \-\-backup\-file=
 This is needed when
 .B \-\-grow

--- a/mdadm.c
+++ b/mdadm.c
@@ -602,6 +602,10 @@ int main(int argc, char *argv[])
 			s.assume_clean = 1;
 			continue;
 
+		case O(CREATE, Discard):
+			s.discard = 1;
+			continue;
+
 		case O(GROW,'n'):
 		case O(CREATE,'n'):
 		case O(BUILD,'n'): /* number of raid disks */

--- a/mdadm.h
+++ b/mdadm.h
@@ -433,6 +433,7 @@ extern char Version[], Usage[], Help[], OptionHelp[],
  */
 enum special_options {
 	AssumeClean = 300,
+	Discard,
 	BitmapChunk,
 	WriteBehind,
 	ReAdd,
@@ -593,6 +594,7 @@ struct shape {
 	int	bitmap_chunk;
 	char	*bitmap_file;
 	int	assume_clean;
+	int	discard;
 	int	write_behind;
 	unsigned long long size;
 	unsigned long long data_offset;


### PR DESCRIPTION
This patchset adds the --discard option for creating new arrays in mdadm.

When specified, mdadm will send block discard (aka. trim or deallocate) requests to all 
of the specified block devices. It will then read back parts of the device to double check that
the disks are now all zeros. If the devices do not support discard, or do not result in zero
data on each disk, an error will be returned.

If all disks get successfully discarded and appear zeroed, then the new array will not need 
to be synchronized. The create operation will then proceed as if --assume-clean was 
specified.

This provides a safe way and fast way to create an array that is ready to go with devices that 
support discard requests. 

Another option for this work is to use a write zero request. This can be done in linux currently 
with fallocate and the FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE flags. This will
send optimized write-zero requests to the devices, without falling back to regular writes
to zero the disk. The benefit of this is that the disk will explicitly read back as zeros, so a zero
check is not necessary. The down side is that not all devices implement this in as optimal
a way as the discard request does and on some of these devices zeroing can take multiple
seconds per GB. 

Because write-zero requests may be slow and most (but not all) discard requests read back 
as zeros, this work chose to use only discard requests.

Will send this upstream after an internal review.